### PR TITLE
chore: upgrade `mail-me-button` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@lay2/pw-core": "^0.4.0-alpha.9",
-    "@mail3/mail3-me": "0.1.4",
+    "@mail3/mail3-me": "0.1.5",
     "@nuxtjs/composition-api": "^0.32.0",
     "@vueuse/core": "^7.7.1",
     "axios": "^0.26.0",

--- a/src/pages/-c/Mai3MeButton.vue
+++ b/src/pages/-c/Mai3MeButton.vue
@@ -12,13 +12,14 @@
   <mail3-me
     class="mail-me-button"
     variant="ghost"
+    :to="email"
     icon_style="margin-right: 8px;color: #000;width: 20px;height: 20px"
     css="font-size: 16px; color: #121314; justify-content: flex-start; width: auto;"
     v-close-popper
   />
 </template>
 
-<script lang="ts">
+<script>
 import { defineComponent } from '@nuxtjs/composition-api'
 import { VClosePopper } from 'floating-vue'
 import '@mail3/mail3-me'
@@ -26,7 +27,15 @@ import '@mail3/mail3-me'
 export default defineComponent({
   name: 'Mail3MeButton',
   directives: {
-    'close-popper': VClosePopper as any,
+    'close-popper': VClosePopper,
+  },
+  props: {
+    account: String,
+  },
+  computed: {
+    email() {
+      return `${this.account}@mail3.me`
+    }
   }
 })
 </script>

--- a/src/pages/-c/ProfileCard.vue
+++ b/src/pages/-c/ProfileCard.vue
@@ -202,7 +202,7 @@
         </button>
         <template #popper>
           <div class="popover_content">
-            <component :is="mail3MeButton" v-if="mail3MeButton" />
+            <component :is="mail3MeButton" v-if="mail3MeButton" :account="account.account" />
           </div>
         </template>
       </Dropdown>
@@ -268,7 +268,7 @@ export default defineComponent({
       // ensure dropdown content is mounted before first shown
       ctx.refs.contactDropdown.$refs.popper.$_ensureTeleport()
       const handleMail3MessageEvent = (event) => {
-        if (event.origin === 'https://app.mail3.me' && event.data.total) {
+        if (event.origin === 'https://app.mail3.me' && Number.isInteger(event.data.total) && event.data.total > 0) {
           hasUnreadMail.value = true
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,10 +1704,10 @@
     jsbi "^3.1.4"
     keccak "^3.0.0"
 
-"@mail3/mail3-me@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@mail3/mail3-me/-/mail3-me-0.1.4.tgz#9764db1cffb427e442e5323a6cd9a209cc45d38d"
-  integrity sha512-7psoczoJyVizEqoFOfNdfCRC7H2+dE4z/lncnH8PjvN/g319iUw7UyuLCig0DORxC/JMoxXI45foBWbVy8UTFg==
+"@mail3/mail3-me@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@mail3/mail3-me/-/mail3-me-0.1.5.tgz#f1cf54a92764d5f3cdb42651fbd4e76f49daaba9"
+  integrity sha512-RLVUjKoFtQuS8jsY4xBbOhN6ageJidE1xn0Eqc5vh2DxsqrL20seSsEFk9FhspVi9R61GV9GmPMn29D9em1RBw==
 
 "@nervosnetwork/ckb-sdk-utils@0.101.0":
   version "0.101.0"


### PR DESCRIPTION
This PR upgrade `mail-me-button` version and passes the .bit address to `mail-me-button`.

@web3max 