### PR TITLE
fix: change Mibao url

### DIFF
--- a/src/serverMiddleware/api_mibao.ts
+++ b/src/serverMiddleware/api_mibao.ts
@@ -32,7 +32,7 @@ function mibaoAuthInterceptor (axiosRequestConfig: AxiosRequestConfig): AxiosReq
 }
 
 const axios = Axios.create({
-  baseURL: 'https://goldenlegend.nervina.cn',
+  baseURL: 'https://api.nftbox.me',
 })
 
 axios.interceptors.request.use(mibaoAuthInterceptor)


### PR DESCRIPTION
Announcement: Mibao NFT platform now rebrands to https://token.city/ (wallet side) and https://nftbox.me/ (issuance side). The OpenAPI url has been changed from [goldenlegend.nervina.cn](http://goldenlegend.nervina.cn/) to https://api.nftbox.me/. Please change your bookmark and development settings before 15th Sep, after which the previous website would be unreachable.